### PR TITLE
Fixes unable to use terminal after starting frida

### DIFF
--- a/AndroidFridaManager/adb.py
+++ b/AndroidFridaManager/adb.py
@@ -50,6 +50,7 @@ class ADB:
         full_cmd = self._build_cmd(["shell", self._elevate_background(cmd)])
         return subprocess.Popen(
             full_cmd,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             start_new_session=True,


### PR DESCRIPTION
When running `afrim` my terminal seems to become unresponsive, and I'm unable to type anything into it anymore, forcing me to close and open it again.
This change fixes that.